### PR TITLE
Fix and improve country/city selection components

### DIFF
--- a/src/components/CertificationsForm.tsx
+++ b/src/components/CertificationsForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Certification } from '../types';
 import { t, Lang } from '../i18n';
 import { RichTextEditor } from './RichTextEditor';
+import { LocationSelector } from './LocationSelector';
 
 interface CertificationsFormProps {
   certifications: Certification[];
@@ -21,7 +22,10 @@ export const CertificationsForm: React.FC<CertificationsFormProps> = ({ certific
       credentialId: '',
       credentialUrl: '',
       description: '',
-      skills: []
+      skills: [],
+      country: '',
+      city: '',
+      location: ''
     };
     onChange([...certifications, newCert]);
   };
@@ -156,6 +160,20 @@ export const CertificationsForm: React.FC<CertificationsFormProps> = ({ certific
                   />
                 </div>
               </div>
+
+              <LocationSelector
+                country={cert.country || ''}
+                city={cert.city || ''}
+                onCountryChange={(country) => {
+                  handleUpdate(cert.id, 'country', country);
+                  handleUpdate(cert.id, 'location', country && cert.city ? `${cert.city}, ${country}` : country || '');
+                }}
+                onCityChange={(city) => {
+                  handleUpdate(cert.id, 'city', city);
+                  handleUpdate(cert.id, 'location', cert.country && city ? `${city}, ${cert.country}` : cert.country || '');
+                }}
+                language={language}
+              />
 
               <div className="form-group">
                 <label className="form-label">{t(language, 'certs.description')}</label>

--- a/src/components/EducationForm.tsx
+++ b/src/components/EducationForm.tsx
@@ -3,6 +3,7 @@ import { Education } from '../types';
 import { degrees } from '../data/degrees';
 import { t, Lang } from '../i18n';
 import { RichTextEditor } from './RichTextEditor';
+import { LocationSelector } from './LocationSelector';
 
 interface EducationFormProps {
   education: Education[];
@@ -23,7 +24,10 @@ export const EducationForm: React.FC<EducationFormProps> = ({ education, onChang
       grade: '',
       activities: '',
       description: '',
-      skills: []
+      skills: [],
+      country: '',
+      city: '',
+      location: ''
     };
     onChange([...education, newEducation]);
   };
@@ -155,6 +159,20 @@ export const EducationForm: React.FC<EducationFormProps> = ({ education, onChang
                   <label htmlFor={`current-${edu.id}`}>{t(language, 'education.currentlyStudying')}</label>
                 </div>
               </div>
+              
+              <LocationSelector
+                country={edu.country || ''}
+                city={edu.city || ''}
+                onCountryChange={(country) => {
+                  handleUpdate(edu.id, 'country', country);
+                  handleUpdate(edu.id, 'location', country && edu.city ? `${edu.city}, ${country}` : country || '');
+                }}
+                onCityChange={(city) => {
+                  handleUpdate(edu.id, 'city', city);
+                  handleUpdate(edu.id, 'location', edu.country && city ? `${city}, ${edu.country}` : edu.country || '');
+                }}
+                language={language}
+              />
               
               <div className="form-row">
                 <div className="form-group">

--- a/src/components/ExperienceForm.tsx
+++ b/src/components/ExperienceForm.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Experience } from '../types';
-import { countries, citiesByCountry } from '../data/locations';
 import { t, Lang } from '../i18n';
 import { RichTextEditor } from './RichTextEditor';
+import { LocationSelector } from './LocationSelector';
 
 interface ExperienceFormProps {
   experiences: Experience[];
@@ -150,45 +150,19 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ experiences, onC
                 </div>
               </div>
               
-              <div className="form-row">
-                <div className="form-group">
-                  <label className="form-label">{t(language, 'experience.country')}</label>
-                  <select
-                    className="form-select"
-                    value={exp.country || ''}
-                    onChange={(e) => {
-                      const country = e.target.value;
-                      const firstCity = country ? citiesByCountry[country]?.[0] || '' : '';
-                      handleUpdate(exp.id, 'country', country);
-                      handleUpdate(exp.id, 'city', firstCity);
-                      handleUpdate(exp.id, 'location', country && firstCity ? `${firstCity}, ${country}` : country || '');
-                    }}
-                  >
-                    <option value="">{t(language, 'experience.selectCountry')}</option>
-                    {countries.map((c) => (
-                      <option key={c} value={c}>{c}</option>
-                    ))}
-                  </select>
-                </div>
-                <div className="form-group">
-                  <label className="form-label">{t(language, 'experience.city')}</label>
-                  <select
-                    className="form-select"
-                    value={exp.city || ''}
-                    onChange={(e) => {
-                      const city = e.target.value;
-                      handleUpdate(exp.id, 'city', city);
-                      handleUpdate(exp.id, 'location', exp.country && city ? `${city}, ${exp.country}` : city);
-                    }}
-                    disabled={!exp.country}
-                  >
-                    <option value="">{exp.country ? t(language, 'experience.selectCity') : t(language, 'experience.selectCountryFirst')}</option>
-                    {(exp.country ? citiesByCountry[exp.country] || [] : []).map((ct) => (
-                      <option key={ct} value={ct}>{ct}</option>
-                    ))}
-                  </select>
-                </div>
-              </div>
+              <LocationSelector
+                country={exp.country || ''}
+                city={exp.city || ''}
+                onCountryChange={(country) => {
+                  handleUpdate(exp.id, 'country', country);
+                  handleUpdate(exp.id, 'location', country && exp.city ? `${exp.city}, ${country}` : country || '');
+                }}
+                onCityChange={(city) => {
+                  handleUpdate(exp.id, 'city', city);
+                  handleUpdate(exp.id, 'location', exp.country && city ? `${city}, ${exp.country}` : exp.country || '');
+                }}
+                language={language}
+              />
 
               <div className="form-group">
                 <label className="form-label">{t(language, 'experience.locationType')}</label>
@@ -239,7 +213,6 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ experiences, onC
                         (e.target as HTMLInputElement).value = '';
                       }
                     }}
-                    className="flex-input"
                   />
                 </div>
                 {exp.skills.length > 0 && (

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { countries, citiesByCountry } from '../data/locations';
+import { t, Lang } from '../i18n';
+
+interface LocationSelectorProps {
+  country: string;
+  city: string;
+  onCountryChange: (country: string) => void;
+  onCityChange: (city: string) => void;
+  language: Lang;
+  disabled?: boolean;
+}
+
+export const LocationSelector: React.FC<LocationSelectorProps> = ({
+  country,
+  city,
+  onCountryChange,
+  onCityChange,
+  language,
+  disabled = false
+}) => {
+  const handleCountryChange = (newCountry: string) => {
+    onCountryChange(newCountry);
+    // Don't auto-select city, let user choose
+    if (city && newCountry) {
+      const citiesInNewCountry = citiesByCountry[newCountry] || [];
+      if (!citiesInNewCountry.includes(city)) {
+        onCityChange(''); // Clear city if not valid for new country
+      }
+    }
+  };
+
+  return (
+    <div className="form-row">
+      <div className="form-group">
+        <label className="form-label">{t(language, 'experience.country')}</label>
+        <select
+          className="form-select"
+          value={country || ''}
+          onChange={(e) => handleCountryChange(e.target.value)}
+          disabled={disabled}
+        >
+          <option value="">{t(language, 'experience.selectCountry')}</option>
+          {countries.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+      </div>
+      <div className="form-group">
+        <label className="form-label">{t(language, 'experience.city')}</label>
+        <select
+          className="form-select"
+          value={city || ''}
+          onChange={(e) => onCityChange(e.target.value)}
+          disabled={!country || disabled}
+        >
+          <option value="">
+            {country 
+              ? t(language, 'experience.selectCity') 
+              : t(language, 'experience.selectCountryFirst')
+            }
+          </option>
+          {(country ? citiesByCountry[country] || [] : []).map((ct) => (
+            <option key={ct} value={ct}>{ct}</option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ProjectsForm.tsx
+++ b/src/components/ProjectsForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Project } from '../types';
 import { t, Lang } from '../i18n';
 import { RichTextEditor } from './RichTextEditor';
+import { LocationSelector } from './LocationSelector';
 
 interface ProjectsFormProps {
   projects: Project[];
@@ -19,7 +20,10 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ projects, onChange, 
       startDate: '',
       endDate: '',
       currentlyWorking: false,
-      associatedWith: ''
+      associatedWith: '',
+      country: '',
+      city: '',
+      location: ''
     };
     onChange([...projects, newProject]);
   };
@@ -150,6 +154,20 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ projects, onChange, 
                   placeholder={t(language, 'projects.associatedPlaceholder')}
                 />
               </div>
+
+              <LocationSelector
+                country={proj.country || ''}
+                city={proj.city || ''}
+                onCountryChange={(country) => {
+                  handleUpdate(proj.id, 'country', country);
+                  handleUpdate(proj.id, 'location', country && proj.city ? `${proj.city}, ${country}` : country || '');
+                }}
+                onCityChange={(city) => {
+                  handleUpdate(proj.id, 'city', city);
+                  handleUpdate(proj.id, 'location', proj.country && city ? `${city}, ${proj.country}` : proj.country || '');
+                }}
+                language={language}
+              />
               
               <div className="form-group">
                 <label className="form-label">{t(language, 'projects.skills')}</label>

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,9 @@ export interface Education {
   activities: string;
   description: string;
   skills: string[];
+  country?: string;
+  city?: string;
+  location?: string;
 }
 
 export interface Certification {
@@ -53,6 +56,9 @@ export interface Certification {
   credentialUrl: string;
   description?: string;
   skills: string[];
+  country?: string;
+  city?: string;
+  location?: string;
 }
 
 export interface Project {
@@ -64,6 +70,9 @@ export interface Project {
   endDate: string;
   currentlyWorking: boolean;
   associatedWith: string;
+  country?: string;
+  city?: string;
+  location?: string;
 }
 
 export interface CVData {


### PR DESCRIPTION
Add country and city selection to Education, Certifications, and Projects forms, and refactor Experience form's location selector for consistency and improved UX.

The previous implementation in the Experience form automatically selected the first city when a country was chosen, which was not ideal. Also, country/city selection was completely missing from other forms. This PR introduces a reusable `LocationSelector` component that allows users to explicitly select a city and integrates this functionality across all relevant forms, ensuring a consistent and user-friendly experience while reducing code duplication.

---
<a href="https://cursor.com/background-agent?bcId=bc-c98e77d6-1914-44fb-9f14-498881009fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c98e77d6-1914-44fb-9f14-498881009fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

