### PR TITLE
Compile and fix typescript error

### DIFF
--- a/extension/src/lib/ai.ts
+++ b/extension/src/lib/ai.ts
@@ -312,7 +312,5 @@ export async function callOpenAI(
     } else {
       return `Unsupported AI provider: ${provider}`;
     }
-  } catch (err) {
-    return `Request failed: ${String(err)}`;
   }
 }


### PR DESCRIPTION
Remove a duplicate `catch` block in `callOpenAI` to fix a TypeScript compilation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bd9dc2b-063d-4178-8222-85116d2092e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2bd9dc2b-063d-4178-8222-85116d2092e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

